### PR TITLE
Add a way to store and restore previous settings at startup

### DIFF
--- a/Nocturnal.xcodeproj/project.pbxproj
+++ b/Nocturnal.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3E4FF22A25BB9EBB00E94F24 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E4FF22925BB9EBB00E94F24 /* Settings.swift */; };
 		7D1B5C302395340E0061D0CF /* CustomTimeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D1B5C2F2395340E0061D0CF /* CustomTimeViewController.swift */; };
 		7D1B5C34239934440061D0CF /* Dimness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D1B5C33239934440061D0CF /* Dimness.swift */; };
 		7D1B5C372399AE770061D0CF /* NSWindow+Fade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D1B5C362399AE770061D0CF /* NSWindow+Fade.swift */; };
@@ -63,6 +64,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3E4FF22925BB9EBB00E94F24 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		7D1B5C2F2395340E0061D0CF /* CustomTimeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTimeViewController.swift; sourceTree = "<group>"; };
 		7D1B5C33239934440061D0CF /* Dimness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dimness.swift; sourceTree = "<group>"; };
 		7D1B5C362399AE770061D0CF /* NSWindow+Fade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "NSWindow+Fade.swift"; path = "Nocturnal/Application/Extensions/NSWindow+Fade.swift"; sourceTree = SOURCE_ROOT; };
@@ -148,6 +150,7 @@
 				7DA5B1F8238BAF9500FE0597 /* NightShift.swift */,
 				7DF36EA6239E730C000CFB5A /* Shortcuts.swift */,
 				7D1B5C38239A39BB0061D0CF /* StateManager.swift */,
+				3E4FF22925BB9EBB00E94F24 /* Settings.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -347,6 +350,7 @@
 				7DA5B1F4238BAC8000FE0597 /* MenuController.swift in Sources */,
 				7D87458B238BFB5A00A676F1 /* DimnessWindowController.swift in Sources */,
 				7DF36EA7239E730C000CFB5A /* Shortcuts.swift in Sources */,
+				3E4FF22A25BB9EBB00E94F24 /* Settings.swift in Sources */,
 				7D1B5C302395340E0061D0CF /* CustomTimeViewController.swift in Sources */,
 				7D1B5C39239A39BB0061D0CF /* StateManager.swift in Sources */,
 				7DF36EAA239EFB29000CFB5A /* PreferencesViewController.swift in Sources */,

--- a/Nocturnal/Application/Main/AppDelegate.swift
+++ b/Nocturnal/Application/Main/AppDelegate.swift
@@ -13,10 +13,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     static var dimnessControllers = [] as [DimnessWindowController]
 
     func applicationDidFinishLaunching(_: Notification) {
+        Settings.initialize()
         Utils.verifyMacOsVersion()
         Utils.verifySupportsNightShift()
         initDimnessControllers()
-        NightShift.strength = 0
+        NightShift.strength = Settings.nightShiftStrength
         NightShift.enable()
         addNotificationObservers()
         Shortcuts.setupShortcuts()

--- a/Nocturnal/Application/Menu/MenuController.swift
+++ b/Nocturnal/Application/Menu/MenuController.swift
@@ -213,7 +213,6 @@ class MenuController: NSMenu, NSMenuDelegate {
 
     @IBAction func quitClicked(_ sender: NSMenuItem) {
         StateManager.isNocturnalEnabled = false
-        NightShift.strength = 1
         NSApplication.shared.terminate(sender)
     }
 }

--- a/Nocturnal/Utils/Dimness.swift
+++ b/Nocturnal/Utils/Dimness.swift
@@ -11,7 +11,7 @@ import Foundation
 enum Dimness {
     public static let maxStrength: Float = 0.9
     private static let fadeDuration = 2.5
-    private static var dimnessStrength: CGFloat = 0
+    private static var dimnessStrength: CGFloat = CGFloat(Settings.dimnessStrength)
     private static var isVisible: Bool = true
 
     static var strength: Float {
@@ -21,6 +21,7 @@ enum Dimness {
             for controller in AppDelegate.dimnessControllers {
                 controller.setAlphaValue(dimnessStrength)
             }
+            Settings.dimnessStrength = newValue
         }
     }
 

--- a/Nocturnal/Utils/NightShift.swift
+++ b/Nocturnal/Utils/NightShift.swift
@@ -25,6 +25,7 @@ enum NightShift {
         }
         set {
             client.setStrength(newValue, commit: true)
+            Settings.nightShiftStrength = newValue;
         }
     }
 

--- a/Nocturnal/Utils/Settings.swift
+++ b/Nocturnal/Utils/Settings.swift
@@ -1,0 +1,33 @@
+//
+//  Settings.swift
+//  Nocturnal
+//
+//  Created by Karanvir Panesar on 1/22/21.
+//  Copyright © 2021 Joshua Jon. All rights reserved.
+//
+
+import Foundation
+
+enum Settings {
+    private static let defaults = UserDefaults.standard
+    private static let dimnessStrengthKey = "DimnessStrength"
+    private static let nightShiftStrengthKey = "NighShiftStrength"
+    private static let initializedKey = "Initialized"
+    
+    static func initialize() {
+        if(!defaults.bool(forKey: initializedKey)) {
+            defaults.set(0.2, forKey: nightShiftStrengthKey)
+            defaults.set(0.2, forKey: dimnessStrengthKey)
+            defaults.set(true, forKey: initializedKey)
+        }
+    }
+    
+    static var dimnessStrength: Float {
+        get { return defaults.float(forKey: dimnessStrengthKey) }
+        set { defaults.set(newValue, forKey: dimnessStrengthKey) }
+    }
+    static var nightShiftStrength: Float {
+        get { return defaults.float(forKey: nightShiftStrengthKey) }
+        set { defaults.set(newValue, forKey: nightShiftStrengthKey) }
+    }
+}


### PR DESCRIPTION
Currently, every time Nocturnal is started, the user has to set the dimness and night shift strength.

This pull request fixes that by adding support for storing the dimness strength and night shift strength values and restores these values at app startup.

P.S. I've never worked with Swift before so forgive me if I've done something incorrectly. I'd be happy to make further changes.